### PR TITLE
[DO NOT MERGE] Store emoji embeddings in Git for streamlit app to work

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,1 +1,0 @@
-/emoji_name_vectorized.npy

--- a/data/emoji_name_vectorized.npy.dvc
+++ b/data/emoji_name_vectorized.npy.dvc
@@ -1,5 +1,0 @@
-outs:
-- md5: 8c2f0636a75f71a205f4418378fb72fc
-  size: 9683072
-  hash: md5
-  path: emoji_name_vectorized.npy


### PR DESCRIPTION
This is not a good idea overall - embeddings are 9mb in size. But there's no quick workaround, so I created this branch to deploy an app to streamlit web platform. We shouldn't merge this branch, but instead we should fix it in the other way.